### PR TITLE
added ascii_font_list() in art.py which returns a list of ascii fonts

### DIFF
--- a/art/__init__.py
+++ b/art/__init__.py
@@ -4,7 +4,7 @@ from .art import artError
 from .art import aprint, art, randart
 from .art import tprint, tsave, text2art
 from .art import decor
-from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list
+from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list, ascii_font_list
 from .art_param import ART_VERSION, FONT_NAMES, ART_NAMES, DECORATION_NAMES, DEFAULT_FONT
 from .art_param import ART_COUNTER, FONT_COUNTER, DECORATION_COUNTER
 from .art_param import NON_ASCII_ARTS, NON_ASCII_FONTS

--- a/art/art.py
+++ b/art/art.py
@@ -78,6 +78,19 @@ def font_list(text="test", mode="all"):
         text_temp = text + "\n"
         tprint(text_temp, str(item))
 
+def ascii_font_list():
+    """
+    Returns a list of ascii fonts
+    :type text : str
+    :type mode: str
+    :return: list
+    """
+    ascii_font_list = []
+    fonts = set(FONT_NAMES) - set(NON_ASCII_FONTS)
+    for item in sorted(list(fonts)):
+        ascii_font_list.append(str(item))
+    return ascii_font_list
+
 
 def art_list(mode="all"):
     """


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
`art.py `, `__init__.py` were modified
I just needed a list of only ascii font names. I didn't see a module for that. I Thought this might be useful for someone else.


#### Any other comments?

