### PR TITLE
Can now get just a list of ascii fonts and ascii arts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@
 # Other Contributors #
 ----------
 - [@heidecjj](https://github.com/heidecjj)
+- [@noobkoder](https://github.com/n00bkoder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `ASCII_FONTS` and `ASCII_ARTS` to `art_param.py`
 ## [5.6] - 2022-04-20
 ### Added
 - 7 new font

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ art.art.artError: The 'number' type must be int.
 
 * Note1 : Use `ART_NAMES` to access all arts name list (new in `Version 4.2`)
 * Note2 : Use `NON_ASCII_ARTS` to access all Non-ASCII arts name list (new in `Version 4.6`)
+* Note3 : Use `ASCII_ARTS` to access all ASCII arts name list.
 
 ### ASCII text
 	
@@ -347,6 +348,7 @@ Filename: test.txt
 
 * Note1 : Use `FONT_NAMES` to access all fonts name list (new in `Version 4.2`)
 * Note2 : Use `NON_ASCII_FONTS` to access all Non-ASCII fonts name list (new in `Version 4.4`)
+* Note3 : Use `ASCII_FONTS` to access all ASCII fonts name list.
 
 ### Decoration
 

--- a/art/__init__.py
+++ b/art/__init__.py
@@ -4,7 +4,7 @@ from .art import artError
 from .art import aprint, art, randart
 from .art import tprint, tsave, text2art
 from .art import decor
-from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list
+from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list, ascii_font_list
 from .art_param import ART_VERSION, FONT_NAMES, ART_NAMES, DECORATION_NAMES, DEFAULT_FONT
 from .art_param import ART_COUNTER, FONT_COUNTER, DECORATION_COUNTER
 from .art_param import NON_ASCII_ARTS, NON_ASCII_FONTS

--- a/art/__init__.py
+++ b/art/__init__.py
@@ -4,8 +4,8 @@ from .art import artError
 from .art import aprint, art, randart
 from .art import tprint, tsave, text2art
 from .art import decor
-from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list, ascii_font_list
+from .art import get_font_dic, set_default, help_func, art_list, font_list, decor_list
 from .art_param import ART_VERSION, FONT_NAMES, ART_NAMES, DECORATION_NAMES, DEFAULT_FONT
 from .art_param import ART_COUNTER, FONT_COUNTER, DECORATION_COUNTER
-from .art_param import NON_ASCII_ARTS, NON_ASCII_FONTS
+from .art_param import NON_ASCII_ARTS, NON_ASCII_FONTS, ASCII_FONTS, ASCII_ARTS
 __version__ = ART_VERSION

--- a/art/art.py
+++ b/art/art.py
@@ -78,6 +78,19 @@ def font_list(text="test", mode="all"):
         text_temp = text + "\n"
         tprint(text_temp, str(item))
 
+def ascii_font_list():
+    """
+    Returns a list of ascii fonts
+    :type text : str
+    :type mode: str
+    :return: list
+    """
+    ascii_font_list = []
+    fonts = set(FONT_NAMES) - set(NON_ASCII_FONTS)
+    for item in sorted(list(fonts)):
+        ascii_font_list.append(str(item))
+    return ascii_font_list
+
 
 def art_list(mode="all"):
     """

--- a/art/art.py
+++ b/art/art.py
@@ -78,19 +78,6 @@ def font_list(text="test", mode="all"):
         text_temp = text + "\n"
         tprint(text_temp, str(item))
 
-def ascii_font_list():
-    """
-    Returns a list of ascii fonts
-    :type text : str
-    :type mode: str
-    :return: list
-    """
-    ascii_font_list = []
-    fonts = set(FONT_NAMES) - set(NON_ASCII_FONTS)
-    for item in sorted(list(fonts)):
-        ascii_font_list.append(str(item))
-    return ascii_font_list
-
 
 def art_list(mode="all"):
     """

--- a/art/art_param.py
+++ b/art/art_param.py
@@ -1722,8 +1722,10 @@ DECORATIONS_MAP = {"angry1": angry1,  # pragma: no cover
                    "wave9": wave9}
 
 FONT_NAMES = sorted(list(FONT_MAP.keys()))  # pragma: no cover
+ASCII_FONTS = sorted(set(FONT_NAMES) - set(NON_ASCII_FONTS))
 DECORATION_NAMES = sorted(list(DECORATIONS_MAP.keys()))  # pragma: no cover
 ART_NAMES = sorted(list(art_dic.keys()))  # pragma: no cover
+ASCII_ARTS = sorted(set(ART_NAMES) - set(NON_ASCII_ARTS))
 FONT_COUNTER = len(FONT_NAMES)  # pragma: no cover
 ART_COUNTER = len(ART_NAMES)  # pragma: no cover
 DECORATION_COUNTER = len(DECORATION_NAMES)  # pragma: no cover


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Adds `ASCII_FONTS` and `ASCII_ARTS` to `art_param.py`
Accesses  list of all ascii fonts and ascii arts respectively  



#### Any other comments?

