### PR TITLE
`font_size_splitter` reproducibility bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- `font_size_splitter` function modified
 - `__detailed_return` parameter added to `art` function
 - `__detailed_return` parameter added to `text2art` function
 - Random mode name bug fixed

--- a/art/art.py
+++ b/art/art.py
@@ -20,12 +20,9 @@ def font_size_splitter(font_map):
     :type font_map : dict
     :return: splitted fonts as dict
     """
-    small_font = []
-    medium_font = []
-    large_font = []
-    xlarge_font = []
+    small_font, medium_font, large_font, xlarge_font = [], [], [], []
     fonts = set(font_map) - set(RANDOM_FILTERED_FONTS)
-    for font in fonts:
+    for font in sorted(fonts):
         length = max(len(x) for x in font_map[font][0].values())
         if length <= FONT_SMALL_THRESHOLD:
             small_font.append(font)


### PR DESCRIPTION
#### Reference Issues/PRs
#257 
#### What does this implement/fix? Explain your changes.
Fixing the `font_size_splitter` reproducibility bug by always sorting `fonts` before use.