### PR TITLE
Drop Python 3.6

### DIFF
--- a/otherfile/meta.yaml
+++ b/otherfile/meta.yaml
@@ -15,9 +15,9 @@ requirements:
     host:
         - pip
         - setuptools
-        - python >=3.6
+        - python >=3.7
     run:
-        - python >=3.6
+        - python >=3.7
 about:
     home: https://github.com/sepandhaghighi/art
     license: MIT

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     extras_require={
         "dev": get_dev_requires()
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -64,7 +64,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- **Python 3.6** dropped officially from `setup.py` and `meta.yaml`

#### Any other comments?

