### PR TITLE
chore: drop support for EOL Python versions (3.6, 3.7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,9 +74,7 @@ body:
         - Python 3.10
         - Python 3.9
         - Python 3.8
-        - Python 3.7
-        - Python 3.6
-        - Python 3.5
+
       default: 1
     validations:
       required: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022, macOS-13]
-        python-version: [3.7, 3.8, 3.9, 3.10.5, 3.11.0, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, 3.10.5, 3.11.0, 3.12.0, 3.13.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,5 @@
 ## Installation
 
-⚠️ **ART 6.4** is the last version to support **Python 3.6** officially	
 
 ⚠️ **ART 6.1** is the last version to support **Python 3.5** officially	
 
@@ -31,7 +30,7 @@
 ### MATLAB
 
 - Download and install [MATLAB](https://www.mathworks.com/products/matlab.html) (>=8.5, 64/32 bit)
-- Download and install [Python3.x](https://www.python.org/downloads/) (>=3.7, 64/32 bit) 
+- Download and install [Python3.x](https://www.python.org/downloads/) (>=3.8, 64/32 bit) 
 	- [x] Select `Add to PATH` option
 	- [x] Select `Install pip` option
 - Run `pip install art`

--- a/otherfile/meta.yaml
+++ b/otherfile/meta.yaml
@@ -15,9 +15,9 @@ requirements:
     host:
         - pip
         - setuptools
-        - python >=3.6
+        - python >=3.8
     run:
-        - python >=3.6
+        - python >=3.8
 about:
     home: https://github.com/sepandhaghighi/art
     license: MIT

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require={
         "dev": get_dev_requires()
     },
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -63,8 +63,7 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
## Description

Python 3.6 and 3.7 have reached end of life. This change removes them from the CI matrix, `setup.py` classifiers, issue template dropdowns, conda recipe, and installation docs.

## Changes

- `setup.py`: Updated `python_requires` to `>=3.8`, removed 3.6/3.7 classifiers
- `.github/workflows/test.yml`: Removed 3.7 from CI matrix
- `.github/ISSUE_TEMPLATE/bug_report.yml`: Removed 3.5/3.6/3.7 from Python version options
- `otherfile/meta.yaml`: Updated conda recipe to `>=3.8`
- `INSTALL.md`: Updated minimum Python version

## Type of Change
- [x] Dependency update

## Related Issue
Fixes #252