### PR TITLE
Validate text2art parameters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@
 - [@eumiro](https://github.com/eumiro)
 - [@AHReccese](https://github.com/AHReccese)
 - [@wcupped](https://github.com/wcupped)
+- [@ChrisJr404](https://github.com/ChrisJr404)
 
 
 ++ **Graphic designer**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Dependencies structure modified
 - Test system modified
 - `tsave` function modified
+- Parameter validation added to `text2art` function
 ## [6.5] - 2025-04-12
 ### Added
 - 1 new 1-line-art

--- a/art/functions.py
+++ b/art/functions.py
@@ -95,6 +95,14 @@ def text2art(
         raise artError(TEXT_TYPE_ERROR)
     if not isinstance(font, str):
         raise artError(FONT_TYPE_ERROR)
+    if not isinstance(chr_ignore, bool):
+        raise artError(CHR_IGNORE_TYPE_ERROR)
+    if decoration is not None and not isinstance(decoration, str):
+        raise artError(DECORATION_TYPE_ERROR)
+    if not isinstance(sep, str):
+        raise artError(SEP_TYPE_ERROR)
+    if not isinstance(space, int):
+        raise artError(SPACE_TYPE_ERROR)
     text = (' ' * space).join(text)
     text_temp = text
     font = font.lower()

--- a/art/tests/test.py
+++ b/art/tests/test.py
@@ -53,19 +53,9 @@ art.art.artError: The 'char' type must be str.
  '----------------'
 <BLANKLINE>
 >>> tprint("\t\t2","block",sep=2)
-<BLANKLINE>
- .----------------.
-| .--------------. |
-| |    _____     | |
-| |   / ___ `.   | |
-| |  |_/___) |   | |
-| |   .'____.'   | |
-| |  / /____     | |
-| |  |_______|   | |
-| |              | |
-| '--------------' |
- '----------------'
-<BLANKLINE>
+Traceback (most recent call last):
+        ...
+art.art.artError: The 'sep' type must be str.
 >>> tprint("\t\t2","block",sep="\n\n")
 <BLANKLINE>
 <BLANKLINE>
@@ -4674,6 +4664,22 @@ art.art.artError: The 'text' type must be str.
 Traceback (most recent call last):
         ...
 art.art.artError: س is invalid.
+>>> text2art("test",chr_ignore="yes")
+Traceback (most recent call last):
+        ...
+art.art.artError: The 'chr_ignore' type must be bool.
+>>> text2art("test",decoration=2)
+Traceback (most recent call last):
+        ...
+art.art.artError: The 'decoration' type must be str.
+>>> text2art("test",sep=2)
+Traceback (most recent call last):
+        ...
+art.art.artError: The 'sep' type must be str.
+>>> text2art("test",space="22")
+Traceback (most recent call last):
+        ...
+art.art.artError: The 'space' type must be int.
 >>> Data=tsave(22,filename="art",chr_ignore=True,print_status=True)
 >>> Data["Message"]
 "The 'text' type must be str."


### PR DESCRIPTION
#### Reference Issues/PRs
#327

#### What does this implement/fix? Explain your changes.
text2art only checked text and font, so passing a bad space raised a raw TypeError while a non-str sep or non-bool chr_ignore were just silently ignored. This adds the same isinstance checks the rest of the package already uses (set_default validates all of these), so invalid chr_ignore, decoration, sep and space now raise artError with a clear message.

#### Any other comments?
I also updated the one tprint doctest that passed sep=2, since that path now raises like the others.